### PR TITLE
Optionally enforce that all non-ignored packages have tests

### DIFF
--- a/gotestiful.go
+++ b/gotestiful.go
@@ -60,7 +60,8 @@ func main() {
 	flagVerbose := flag.Bool("v", conf.Verbose, "Verbose output: run tests with verbose output eg. 'go test -v'")
 	flagListIgnored := flag.Bool("listignored", conf.ListIgnored, "Excluded packages: list ignored packages (at the end)")
 	flagSkipEmpty := flag.Bool("skipempty", conf.SkipEmpty, "No tests omit: do not show packages with no tests in the output (affects coverage)")
-	flagListEmpty := flag.Bool("listempty", conf.ListEmpty, "No tests list: list packages with no tests (at the end)")
+	flagListEmpty := flag.Bool("listempty", conf.ListEmpty, "No tests list: list packages with no tests (at the end). WIll also cause the program to exit with status 1")
+
 	flag.Usage = gtf.PrintHelp
 	flag.Parse()
 

--- a/internal/output.go
+++ b/internal/output.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -18,6 +19,8 @@ type processOutputParams struct {
 	FlagListEmpty   bool
 	FlagListIgnored bool
 	IndentSpaces    int
+
+	Err *error
 }
 
 func processOutput(params *processOutputParams) {
@@ -184,6 +187,9 @@ func processOutput(params *processOutputParams) {
 		params.LineOut(shColor("yellow:bold", "Packages with no tests:"))
 		for _, pkg := range pkgsNoTests {
 			params.LineOut("- " + pkg)
+		}
+		if len(pkgsNoTests) != 0 {
+			*params.Err = errors.New("there are packages without tests")
 		}
 	}
 

--- a/internal/shell.go
+++ b/internal/shell.go
@@ -42,6 +42,10 @@ func shJSONPipe[T any](prog string, args shArgs, stdIn string, eventPipe chan<- 
 
 	cmd := exec.Command(prog, args...)
 	stdout, _ := cmd.StdoutPipe()
+
+	var stdErr bytes.Buffer
+	cmd.Stderr = &stdErr
+
 	err := cmd.Start()
 	if err != nil {
 		return fmt.Errorf("failed to run %s: %w", prog, err)
@@ -63,6 +67,9 @@ func shJSONPipe[T any](prog string, args shArgs, stdIn string, eventPipe chan<- 
 	err = cmd.Wait()
 
 	if err != nil {
+		// print out the stdout back to stdout so we can debug
+		fmt.Fprintln(os.Stderr, stdErr.String())
+
 		return fmt.Errorf("failed to run %s: %w", prog, err)
 	}
 	return nil


### PR DESCRIPTION
This is useful for coverage testing, to make sure all packages have tests and the code is measured. I will be adding more code to init those, which will make it simple.