### PR TITLE
Parse the output from JSON, not from STDOUT

### DIFF
--- a/internal/shell_test.go
+++ b/internal/shell_test.go
@@ -14,9 +14,13 @@ func TestShCmd(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestShPipe(t *testing.T) {
-	out := []string{}
-	c := make(chan string)
+func TestShJSONPipe(t *testing.T) {
+	type Inp struct {
+		Foo string
+		Bar string
+	}
+	out := []Inp{}
+	c := make(chan Inp)
 	var wg sync.WaitGroup
 	wg.Add(1)
 
@@ -27,10 +31,19 @@ func TestShPipe(t *testing.T) {
 		wg.Done()
 	}()
 
-	shPipe("echo", shArgs{"Hello\nWorld"}, "", c)
+	shJSONPipe("echo", shArgs{`{"Foo": "1",
+		"Bar":"2"
+	}
+	{"Foo": "3", "Bar": "4"}
+	{"Foo":"5"}{"Bar": "6"}`}, "", c)
 	wg.Wait()
 
-	assert.Equal(t, out, []string{"Hello", "World"})
+	assert.Equal(t, out, []Inp{
+		{Foo: "1", Bar: "2"},
+		{Foo: "3", Bar: "4"},
+		{Foo: "5"},
+		{Bar: "6"},
+	})
 }
 
 func TestShColor(t *testing.T) {


### PR DESCRIPTION
This is actually somewhat _more_ complex, because we need to implement the verbosity logic ourselves and not leave it up to go (as go with JSON output just always prints all); however, I think it's still less error-prone, as we now always know what line belongs to what package/test and we don't need to "guess" by previous/next lines.

I have changed the tests by "capturing" real data from real toy tests; but I tried to keep all the current testcases.

I deleted the shPipe function, as it was no longer needed.