### PR TITLE
Remove log.Fatal in logic and replace with Errors

### DIFF
--- a/gotestiful.go
+++ b/gotestiful.go
@@ -42,6 +42,7 @@ package main
 
 import (
 	"flag"
+	"log"
 
 	gtf "github.com/alex-parra/gotestiful/internal"
 )
@@ -49,7 +50,10 @@ import (
 const version = "v0.1.4"
 
 func main() {
-	conf := gtf.GetConfig()
+	conf, err := gtf.GetConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	flagVersion := flag.Bool("version", false, "Gotestiful version: print version information")
 	flagColor := flag.Bool("color", conf.Color, "Colorize output: turn colorized output on/off")
@@ -74,10 +78,13 @@ func main() {
 		gtf.PrintVersion(version)
 
 	case testPath == "init":
-		gtf.InitConfig()
+		err := gtf.InitConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
 
 	default:
-		gtf.RunTests(gtf.RunTestsOpts{
+		err := gtf.RunTests(gtf.RunTestsOpts{
 			TestPath:         testPath,
 			FlagColor:        *flagColor,
 			FlagCache:        *flagCache,
@@ -90,6 +97,9 @@ func main() {
 			FlagListEmpty:    *flagListEmpty,
 			Excludes:         conf.Exclude,
 		})
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 )
@@ -37,39 +36,47 @@ var conf = config{
 	Exclude: []string{},
 }
 
-func GetConfig() config {
-	pwd := getPWD()
+func GetConfig() (config, error) {
+	pwd, err := getPWD()
+	if err != nil {
+		return config{}, err
+	}
 	confPath := filepath.Join(pwd, configFileName)
 
 	if fileExists(confPath) {
 		confBytes, err := readFile(confPath)
 		if err != nil {
-			log.Fatal(fmt.Errorf("failed to read config file: %w", err))
+			return config{}, fmt.Errorf("failed to read config file: %w", err)
 		}
 
 		err = json.Unmarshal(confBytes, &conf)
 		if err != nil {
-			log.Fatal(fmt.Errorf("failed to read config file: %w", err))
+			return config{}, fmt.Errorf("failed to read config file: %w", err)
 		}
 	}
 
-	return conf
+	return conf, nil
 }
 
 // Creates a config file in the current path with default values
-func InitConfig() {
-	pwd := getPWD()
+func InitConfig() error {
+	pwd, err := getPWD()
+	if err != nil {
+		return err
+	}
 	confPath := filepath.Join(pwd, configFileName)
 
 	if fileExists(confPath) {
-		log.Fatalf("config file already exits at %s", confPath)
+		return fmt.Errorf("config file already exits at %s", confPath)
 	}
 
 	data, _ := json.MarshalIndent(conf, "", "  ")
 
-	err := os.WriteFile(confPath, data, 0644)
+	err = os.WriteFile(confPath, data, 0644)
 
 	if err != nil {
-		log.Fatal(fmt.Errorf("failed to init config: %w", err))
+		return fmt.Errorf("failed to init config: %w", err)
 	}
+
+	return nil
 }

--- a/internal/exclude.go
+++ b/internal/exclude.go
@@ -1,13 +1,13 @@
 package internal
 
 import (
-	"log"
+	"fmt"
 	"regexp"
 )
 
-func excludePackages(packages, excludes []string) ([]string, []string) {
+func excludePackages(packages, excludes []string) ([]string, []string, error) {
 	if len(excludes) == 0 {
-		return packages, nil
+		return packages, nil, nil
 	}
 
 	excludeRegexs := make([]*regexp.Regexp, 0, len(excludes))
@@ -18,7 +18,7 @@ func excludePackages(packages, excludes []string) ([]string, []string) {
 		}
 		regex, err := regexp.Compile("^" + exclude)
 		if err != nil {
-			log.Fatalf("cannot compile regex %q: %+v", exclude, regex)
+			return nil, nil, fmt.Errorf("cannot compile regex %q: %+v", exclude, regex)
 		}
 		excludeRegexs = append(excludeRegexs, regex)
 	}
@@ -37,5 +37,5 @@ func excludePackages(packages, excludes []string) ([]string, []string) {
 			excluded = append(excluded, pkg)
 		}
 	}
-	return included, excluded
+	return included, excluded, nil
 }

--- a/internal/exclude_test.go
+++ b/internal/exclude_test.go
@@ -54,7 +54,8 @@ func TestExclude(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			included, ignored := excludePackages(tst.packages, tst.excluded)
+			included, ignored, err := excludePackages(tst.packages, tst.excluded)
+			assert.NoError(t, err)
 			assert.Equal(t, tst.expectedIncluded, included)
 			assert.Equal(t, tst.expectedIgnored, ignored)
 		})

--- a/internal/filesys.go
+++ b/internal/filesys.go
@@ -2,16 +2,15 @@ package internal
 
 import (
 	"fmt"
-	"log"
 	"os"
 )
 
-func getPWD() string {
+func getPWD() (string, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
-		log.Fatal(fmt.Errorf("failed to get current directory: %w", err))
+		return "", fmt.Errorf("failed to get current directory: %w", err)
 	}
-	return pwd
+	return pwd, err
 }
 
 func fileExists(filename string) bool {

--- a/internal/shell.go
+++ b/internal/shell.go
@@ -16,7 +16,7 @@ import (
 type shArgs []string
 
 // shCmd runs a shell command with given args and returns the output
-func shCmd(prog string, args shArgs, stdIn string) string {
+func shCmd(prog string, args shArgs, stdIn string) (string, error) {
 	cmd := exec.Command(prog, args...)
 
 	cmd.Stdin = strings.NewReader(stdIn)
@@ -31,10 +31,10 @@ func shCmd(prog string, args shArgs, stdIn string) string {
 	if err != nil {
 		// print out the stdout back to stdout so we can debug
 		fmt.Fprintln(os.Stderr, stdErr.String())
-		log.Fatal(fmt.Errorf("failed to run %s: %w", prog, err))
+		return "", fmt.Errorf("failed to run %s: %w", prog, err)
 	}
 
-	return stdOut.String()
+	return stdOut.String(), nil
 }
 
 func shJSONPipe[T any](prog string, args shArgs, stdIn string, eventPipe chan<- T) error {
@@ -54,7 +54,7 @@ func shJSONPipe[T any](prog string, args shArgs, stdIn string, eventPipe chan<- 
 			if err == io.EOF {
 				break
 			}
-			log.Fatalf("reading shell output: %v", err)
+			return fmt.Errorf("reading shell output: %v", err)
 		}
 
 		eventPipe <- m

--- a/internal/shell_test.go
+++ b/internal/shell_test.go
@@ -10,8 +10,9 @@ import (
 
 func TestShCmd(t *testing.T) {
 	expected := "Hello\n"
-	actual := shCmd("echo", shArgs{"Hello"}, "")
+	actual, err := shCmd("echo", shArgs{"Hello"}, "")
 	assert.Equal(t, expected, actual)
+	assert.NoError(t, err)
 }
 
 func TestShJSONPipe(t *testing.T) {


### PR DESCRIPTION
One negative of log.Fatal() is that, unlike panic or error, it does *not* run defered functions. It immediately exits the program and all other goroutines that are running.

It doesn't currently matter, as we don't do any cleanup in any defer function, but it can be confusing.

Also it's cleaner, I think.