### PR TITLE
Add option for including files with empty tests in coverage reports

### DIFF
--- a/.gotestiful
+++ b/.gotestiful
@@ -8,5 +8,6 @@
   "listIgnored": false,
   "skipEmpty": true,
   "listEmpty": false,
-  "exclude": []
+  "exclude": [],
+  "emptyInCoverage": true
 }

--- a/gotestiful.go
+++ b/gotestiful.go
@@ -65,6 +65,7 @@ func main() {
 	flagListIgnored := flag.Bool("listignored", conf.ListIgnored, "Excluded packages: list ignored packages (at the end)")
 	flagSkipEmpty := flag.Bool("skipempty", conf.SkipEmpty, "No tests omit: do not show packages with no tests in the output (affects coverage)")
 	flagListEmpty := flag.Bool("listempty", conf.ListEmpty, "No tests list: list packages with no tests (at the end)")
+	flagEmptyInCoverage := flag.Bool("emptyInCoverage", conf.EmptyInCoverage, "Include empty tests in coverage reports.")
 	flag.Usage = gtf.PrintHelp
 	flag.Parse()
 
@@ -85,17 +86,18 @@ func main() {
 
 	default:
 		err := gtf.RunTests(gtf.RunTestsOpts{
-			TestPath:         testPath,
-			FlagColor:        *flagColor,
-			FlagCache:        *flagCache,
-			FlagCover:        *flagCover,
-			FlagCoverReport:  *flagCoverReport,
-			FlagCoverProfile: *flagCoverProfile,
-			FlagVerbose:      *flagVerbose,
-			FlagListIgnored:  *flagListIgnored,
-			FlagSkipEmpty:    *flagSkipEmpty,
-			FlagListEmpty:    *flagListEmpty,
-			Excludes:         conf.Exclude,
+			TestPath:            testPath,
+			FlagColor:           *flagColor,
+			FlagCache:           *flagCache,
+			FlagCover:           *flagCover,
+			FlagCoverReport:     *flagCoverReport,
+			FlagCoverProfile:    *flagCoverProfile,
+			FlagVerbose:         *flagVerbose,
+			FlagListIgnored:     *flagListIgnored,
+			FlagSkipEmpty:       *flagSkipEmpty,
+			FlagListEmpty:       *flagListEmpty,
+			FlagEmptyInCoverage: *flagEmptyInCoverage,
+			Excludes:            conf.Exclude,
 		})
 		if err != nil {
 			log.Fatal(err)

--- a/internal/config.go
+++ b/internal/config.go
@@ -10,16 +10,17 @@ import (
 const configFileName = ".gotestiful"
 
 type config struct {
-	Color        bool     `json:"color"`
-	Cache        bool     `json:"cache"`
-	Cover        bool     `json:"cover"`
-	Report       bool     `json:"report"`
-	CoverProfile string   `json:"coverProfile"`
-	Verbose      bool     `json:"verbose"`
-	ListIgnored  bool     `json:"listIgnored"`
-	SkipEmpty    bool     `json:"skipEmpty"`
-	ListEmpty    bool     `json:"listEmpty"`
-	Exclude      []string `json:"exclude"`
+	Color           bool     `json:"color"`
+	Cache           bool     `json:"cache"`
+	Cover           bool     `json:"cover"`
+	Report          bool     `json:"report"`
+	CoverProfile    string   `json:"coverProfile"`
+	Verbose         bool     `json:"verbose"`
+	ListIgnored     bool     `json:"listIgnored"`
+	SkipEmpty       bool     `json:"skipEmpty"`
+	ListEmpty       bool     `json:"listEmpty"`
+	EmptyInCoverage bool     `json:"emptyInCoverage"`
+	Exclude         []string `json:"exclude"`
 }
 
 // Default config values

--- a/internal/main.go
+++ b/internal/main.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -9,18 +10,24 @@ import (
 	"github.com/fatih/color"
 )
 
+type RunInitEmptyOpts struct {
+	TestPath string
+	Excludes []string
+}
+
 type RunTestsOpts struct {
-	TestPath         string
-	FlagColor        bool
-	FlagCache        bool
-	FlagCover        bool
-	FlagCoverReport  bool
-	FlagCoverProfile string
-	FlagVerbose      bool
-	FlagListIgnored  bool
-	FlagSkipEmpty    bool
-	FlagListEmpty    bool
-	Excludes         []string
+	TestPath            string
+	FlagColor           bool
+	FlagCache           bool
+	FlagCover           bool
+	FlagCoverReport     bool
+	FlagCoverProfile    string
+	FlagVerbose         bool
+	FlagListIgnored     bool
+	FlagSkipEmpty       bool
+	FlagListEmpty       bool
+	FlagEmptyInCoverage bool
+	Excludes            []string
 }
 
 type TestEvent struct {
@@ -32,7 +39,115 @@ type TestEvent struct {
 	Output  string
 }
 
+type Package struct {
+	Dir        string
+	ImportPath string
+	Name       string
+}
+
+func initEmpty(testPath string, excludes []string) (newFiles []string, packages []Package, err error) {
+	allPkgs := []string{}
+	allPkgsMap := map[string]Package{}
+
+	{
+		pkgChan := make(chan Package)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			for p := range pkgChan {
+				allPkgs = append(allPkgs, p.ImportPath)
+				allPkgsMap[p.ImportPath] = p
+			}
+			wg.Done()
+		}()
+		err := shJSONPipe("go", shArgs{"list", "-json", testPath}, "", pkgChan)
+		wg.Wait()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	skippedPkgs := []string{}
+
+	{
+		testPkgs, _, err := excludePackages(allPkgs, excludes)
+
+		goListOutput := make(chan TestEvent)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go func() {
+			for o := range goListOutput {
+				if o.Action == "skip" && o.Test == "" {
+					skippedPkgs = append(skippedPkgs, o.Package)
+				}
+			}
+
+			wg.Done()
+		}()
+
+		testArgs := shArgs{"test"}
+		testArgs = append(testArgs, "-list", ".")
+		testArgs = append(testArgs, "-json")
+		testArgs = append(testArgs, testPkgs...)
+		err = shJSONPipe("go", testArgs, "", goListOutput)
+		wg.Wait()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	defer func() {
+		if err != nil {
+			for _, f := range newFiles {
+				os.Remove(f)
+			}
+		}
+	}()
+
+	for _, importPath := range skippedPkgs {
+		p, ok := allPkgsMap[importPath]
+		if !ok {
+			return nil, nil, fmt.Errorf("package %q not found in map", importPath)
+		}
+
+		// this is all that's need to be printed to be a valid test
+		textToWrite := "package " + p.Name + "\n"
+
+		file, err := os.CreateTemp(p.Dir, "dummy_*_test.go")
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// we know we can write to dummy_test, because there is no test in the package
+		err = os.WriteFile(file.Name(), []byte(textToWrite), 0o666)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		newFiles = append(newFiles, file.Name())
+		packages = append(packages, p)
+	}
+	return newFiles, packages, nil
+}
+
 func RunTests(opts RunTestsOpts) error {
+	var newFiles []string
+	var newPackages []Package
+	if opts.FlagEmptyInCoverage {
+		var err error
+		newFiles, newPackages, err = initEmpty(opts.TestPath, opts.Excludes)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			for _, f := range newFiles {
+				os.Remove(f)
+			}
+		}()
+	}
+
 	color.NoColor = !opts.FlagColor
 	coverProfile := zvfb(opts.FlagCoverProfile, "./coverage.out")
 
@@ -68,6 +183,7 @@ func RunTests(opts RunTestsOpts) error {
 			FlagListEmpty:   opts.FlagListEmpty,
 			FlagListIgnored: opts.FlagListIgnored,
 			IndentSpaces:    2,
+			DummyPackages:   newPackages,
 		})
 		wg.Done()
 	}()


### PR DESCRIPTION
The way we do this is a little tricky.
* first we list all packages, to get file paths/names
* then we get all the packages without tests, through go test list
* then we create dummy test files
* then we run the gotestiful
* then we remove the dummy files

We need to do some trickery to still print the originally no-test files
as skipped.

Note that with the current coverage reporting, which is wrong (as it just averages all coverages),
there is no difference in overall coverage reporting; I plan to do one more PR that will fix the overall coverage
reporting

Note that this depends on/includes #5 