### PR TITLE
Do proper counting of coverage

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -34,7 +36,6 @@ type TestEvent struct {
 
 func RunTests(opts RunTestsOpts) error {
 	color.NoColor = !opts.FlagColor
-	coverProfile := zvfb(opts.FlagCoverProfile, "./coverage.out")
 
 	// Get list of all packages in the test path
 	allPkgsStr, err := shCmd("go", shArgs{"list", opts.TestPath}, "")
@@ -72,17 +73,36 @@ func RunTests(opts RunTestsOpts) error {
 		wg.Done()
 	}()
 
+	var coverProfile string
+	if opts.FlagCoverReport {
+		coverProfile = zvfb(opts.FlagCoverProfile, "./coverage.out")
+	} else {
+		newF, err := os.CreateTemp("", "coverage-*.out")
+		if err != nil {
+			return err
+		}
+		defer os.Remove(newF.Name())
+		coverProfile = newF.Name()
+	}
+
 	// Compose and run 'go test ...'
 	lineOut(sf("\nTesting %d packages in '%s'\n", len(testPkgs), opts.TestPath))
 	testArgs := shArgs{"test"}
 	testArgs = sliceAppendIf(opts.FlagVerbose, testArgs, "-v")
 	testArgs = sliceAppendIf(!opts.FlagCache, testArgs, "-count=1")
 	testArgs = sliceAppendIf(opts.FlagCover, testArgs, "-cover")
-	testArgs = sliceAppendIf(opts.FlagCoverProfile != "" || opts.FlagCoverReport, testArgs, "-coverprofile="+coverProfile)
+	testArgs = append(testArgs, "-coverprofile="+coverProfile)
 	testArgs = append(testArgs, "-json")
 	testArgs = append(testArgs, testPkgs...)
 	err = shJSONPipe("go", testArgs, "", goTestOutput)
 	wg.Wait()
+	if err != nil {
+		// print coverage even in the case of error (as test failure is error here); ignore its own error
+		printCoverage(coverProfile, lineOut)
+		return err
+	}
+
+	err = printCoverage(coverProfile, lineOut)
 	if err != nil {
 		return err
 	}
@@ -91,5 +111,37 @@ func RunTests(opts RunTestsOpts) error {
 	if opts.FlagCoverReport {
 		shCmd("go", shArgs{"tool", "cover", "-html=" + coverProfile}, "")
 	}
+	return nil
+}
+
+func printCoverage(path string, lineOut func(...string)) error {
+	var coverage float64
+
+	// now read proper code coverage
+	goCoverOutput := make(chan string)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		for line := range goCoverOutput {
+			if strings.HasPrefix(line, "total:") {
+				// a bit of a hack but it works
+				line = strings.Trim(line, "total: (statements) %\t\n")
+				coverage, _ = strconv.ParseFloat(line, 64)
+			}
+		}
+		wg.Done()
+	}()
+
+	err := shPipe("go", shArgs{"tool", "cover", "-func", path}, "", goCoverOutput)
+	if err != nil {
+		return err
+	}
+
+	chev := shColor("gray", "❯")
+	cover := sf("%.2f", coverage) + "%"
+
+	lineOut(sf("%s Coverage: %s", chev, shColor(coverageColor(coverage)+":bold", cover)))
 	return nil
 }

--- a/internal/output.go
+++ b/internal/output.go
@@ -35,7 +35,6 @@ func processOutput(params *processOutputParams) {
 
 	pkgsNoTests := []string{}
 	pkgsFailed := []string{}
-	coverages := []float64{}
 
 	// the JSON output is printing all verbose; so we need to implement the FAIL output filtering ourselves
 	linesPerTest := map[string][]string{}
@@ -116,7 +115,6 @@ func processOutput(params *processOutputParams) {
 		if event.Test == "" && event.Action == "skip" {
 			pkg := event.Package
 			pkgsNoTests = append(pkgsNoTests, pkg)
-			coverages = append(coverages, 0)
 
 			if params.FlagSkipEmpty {
 				continue
@@ -144,7 +142,6 @@ func processOutput(params *processOutputParams) {
 			} else {
 				pkgCoverage := regexCoverageNonZero.ReplaceAllString(pastCoverage, "$1")
 				c := coverageParse(pkgCoverage)
-				coverages = append(coverages, c)
 
 				outLine += "   "
 				outLine += shColor(coverageColor(c), sf("%6s", pkgCoverage))
@@ -169,9 +166,6 @@ func processOutput(params *processOutputParams) {
 	params.LineOut()
 
 	chev := shColor("gray", "❯")
-	avgCoverage := sliceAvg(coverages)
-	cover := sf("%.2f", avgCoverage) + "%"
-	params.LineOut(sf("%s Coverage: %s", chev, shColor(coverageColor(avgCoverage)+":bold", cover)))
 	pkgs := sf("tested: %d", len(params.ToTestPackages))
 	pkgs += shColor("red", sf("    failed: %d", len(pkgsFailed)))
 	pkgs += shColor("yellow", sf("    noTests: %d", len(pkgsNoTests)))

--- a/internal/output_test.go
+++ b/internal/output_test.go
@@ -62,7 +62,6 @@ func TestProcessOutput(t *testing.T) {
 		assert.Equal(t, out, []string{
 			"✔ tst              0.266s",
 			"",
-			"❯ Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
 			"",
 		})
@@ -85,7 +84,6 @@ func TestProcessOutput(t *testing.T) {
 		assert.Equal(t, out, []string{
 			"✔ tst     0.0%     0.266s",
 			"",
-			"❯ Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
 			"",
 		})
@@ -113,7 +111,6 @@ func TestProcessOutput(t *testing.T) {
 			"  code_test.go:10: some reason to skip",
 			"✔ tst              0.266s",
 			"",
-			"❯ Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
 			"",
 		})
@@ -143,7 +140,6 @@ func TestProcessOutput(t *testing.T) {
 			"  code_test.go:12: but a test ain't one",
 			"◼ tst              0.308s",
 			"",
-			"❯ Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 1    noTests: 0    excluded: 0",
 			"",
 		})
@@ -160,7 +156,6 @@ func TestProcessOutput(t *testing.T) {
 		assert.Equal(t, out, []string{
 			"! tst     0.0%     no tests",
 			"",
-			"❯ Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 1    excluded: 0",
 			"",
 		})
@@ -176,7 +171,6 @@ func TestProcessOutput(t *testing.T) {
 
 		assert.Equal(t, out, []string{
 			"",
-			"❯ Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 1    excluded: 0",
 			"",
 		})
@@ -193,7 +187,6 @@ func TestProcessOutput(t *testing.T) {
 		assert.Equal(t, out, []string{
 			"! tst     0.0%     no tests",
 			"",
-			"❯ Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 1    excluded: 0",
 			"",
 			"Packages with no tests:",
@@ -219,7 +212,6 @@ func TestProcessOutput(t *testing.T) {
 		assert.Equal(t, out, []string{
 			"✔ tst    50.0%     0.186s",
 			"",
-			"❯ Coverage: 50.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
 			"",
 		})
@@ -243,7 +235,6 @@ func TestProcessOutput(t *testing.T) {
 		assert.Equal(t, out, []string{
 			"✔ tst        -     no statements",
 			"",
-			"❯ Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
 			"",
 		})
@@ -280,7 +271,6 @@ func TestProcessOutput(t *testing.T) {
 			"  code_test.go:12: but a test ain't one",
 			"◼ tst    50.0%     0.108s",
 			"",
-			"❯ Coverage: 50.00%",
 			"❯ Pkgs: tested: 1    failed: 1    noTests: 0    excluded: 0",
 			"",
 		})
@@ -321,7 +311,6 @@ func TestProcessOutput(t *testing.T) {
 			"◼ tst    50.0%     0.108s",
 			"-------------------------",
 			"",
-			"❯ Coverage: 50.00%",
 			"❯ Pkgs: tested: 1    failed: 1    noTests: 0    excluded: 0",
 			""})
 	})
@@ -344,7 +333,6 @@ func TestProcessOutput(t *testing.T) {
 		assert.Equal(t, out, []string{
 			"✔ tst    50.0%     0.186s",
 			"",
-			"❯ Coverage: 50.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 1",
 			"",
 		})
@@ -368,7 +356,6 @@ func TestProcessOutput(t *testing.T) {
 		assert.Equal(t, out, []string{
 			"✔ tst    50.0%     0.186s",
 			"",
-			"❯ Coverage: 50.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 1",
 			"",
 			"Packages ignored:",

--- a/internal/shell_test.go
+++ b/internal/shell_test.go
@@ -47,6 +47,25 @@ func TestShJSONPipe(t *testing.T) {
 	})
 }
 
+func TestShPipe(t *testing.T) {
+	out := []string{}
+	c := make(chan string)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		for line := range c {
+			out = append(out, line)
+		}
+		wg.Done()
+	}()
+
+	shPipe("echo", shArgs{"Hello\nWorld"}, "", c)
+	wg.Wait()
+
+	assert.Equal(t, out, []string{"Hello", "World"})
+}
+
 func TestShColor(t *testing.T) {
 	t.Run("no color", func(t *testing.T) {
 		color.NoColor = true


### PR DESCRIPTION
This needs to always save the cover file, so let's do a temporary one and delete it if the user didn't want it.