### PR TITLE
Add option for displaying and counting proper full coverage

### DIFF
--- a/.gotestiful
+++ b/.gotestiful
@@ -8,5 +8,6 @@
   "listIgnored": false,
   "skipEmpty": true,
   "listEmpty": false,
-  "exclude": []
+  "exclude": [],
+  "fullCoverage": true
 }

--- a/gotestiful.go
+++ b/gotestiful.go
@@ -60,11 +60,12 @@ func main() {
 	flagCache := flag.Bool("cache", conf.Cache, "Test caching: tests cache on/off eg. 'go test -count=1' if false")
 	flagCover := flag.Bool("cover", conf.Cover, "Coverage: turn coverage reporting on/off eg. 'go test -cover'")
 	flagCoverReport := flag.Bool("report", conf.Report, "Coverage details: open html coverage report eg. 'go tool cover -html'")
-	flagCoverProfile := flag.String("coverprofile", conf.CoverProfile, "Coverage profile: coverage report output file path (default ./coverage.out)")
+	flagCoverProfile := flag.String("coverprofile", conf.CoverProfile, "Coverage profile: coverage report output file path (default ./coverage.out). Takes longer (disables caching).")
 	flagVerbose := flag.Bool("v", conf.Verbose, "Verbose output: run tests with verbose output eg. 'go test -v'")
 	flagListIgnored := flag.Bool("listignored", conf.ListIgnored, "Excluded packages: list ignored packages (at the end)")
 	flagSkipEmpty := flag.Bool("skipempty", conf.SkipEmpty, "No tests omit: do not show packages with no tests in the output (affects coverage)")
 	flagListEmpty := flag.Bool("listempty", conf.ListEmpty, "No tests list: list packages with no tests (at the end)")
+	flagFullCoverage := flag.Bool("fullCoverage", conf.FullCoverage, "Count overall coverage including packages without tests. Takes longer (disables caching).")
 	flag.Usage = gtf.PrintHelp
 	flag.Parse()
 
@@ -95,6 +96,7 @@ func main() {
 			FlagListIgnored:  *flagListIgnored,
 			FlagSkipEmpty:    *flagSkipEmpty,
 			FlagListEmpty:    *flagListEmpty,
+			FlagFullCoverage: *flagFullCoverage,
 			Excludes:         conf.Exclude,
 		})
 		if err != nil {

--- a/internal/config.go
+++ b/internal/config.go
@@ -19,6 +19,7 @@ type config struct {
 	ListIgnored  bool     `json:"listIgnored"`
 	SkipEmpty    bool     `json:"skipEmpty"`
 	ListEmpty    bool     `json:"listEmpty"`
+	FullCoverage bool     `json:"fullCoverage"`
 	Exclude      []string `json:"exclude"`
 }
 

--- a/internal/main.go
+++ b/internal/main.go
@@ -2,12 +2,19 @@ package internal
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/fatih/color"
 )
+
+type RunInitEmptyOpts struct {
+	TestPath string
+	Excludes []string
+}
 
 type RunTestsOpts struct {
 	TestPath         string
@@ -20,6 +27,7 @@ type RunTestsOpts struct {
 	FlagListIgnored  bool
 	FlagSkipEmpty    bool
 	FlagListEmpty    bool
+	FlagFullCoverage bool
 	Excludes         []string
 }
 
@@ -32,9 +40,122 @@ type TestEvent struct {
 	Output  string
 }
 
+type Package struct {
+	Dir        string
+	ImportPath string
+	Name       string
+}
+
+func initEmpty(testPath string, excludes []string) (newFiles []string, packages []Package, err error) {
+	allPkgs := []string{}
+	allPkgsMap := map[string]Package{}
+
+	{
+		pkgChan := make(chan Package)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			for p := range pkgChan {
+				allPkgs = append(allPkgs, p.ImportPath)
+				allPkgsMap[p.ImportPath] = p
+			}
+			wg.Done()
+		}()
+		err := shJSONPipe("go", shArgs{"list", "-json", testPath}, "", pkgChan)
+		wg.Wait()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	skippedPkgs := []string{}
+
+	{
+		testPkgs, _, err := excludePackages(allPkgs, excludes)
+
+		goListOutput := make(chan TestEvent)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go func() {
+			for o := range goListOutput {
+				if o.Action == "skip" && o.Test == "" {
+					skippedPkgs = append(skippedPkgs, o.Package)
+				}
+			}
+
+			wg.Done()
+		}()
+
+		testArgs := shArgs{"test"}
+		testArgs = append(testArgs, "-list", ".")
+		testArgs = append(testArgs, "-json")
+		testArgs = append(testArgs, testPkgs...)
+		err = shJSONPipe("go", testArgs, "", goListOutput)
+		wg.Wait()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	defer func() {
+		if err != nil {
+			for _, f := range newFiles {
+				os.Remove(f)
+			}
+		}
+	}()
+
+	for _, importPath := range skippedPkgs {
+		p, ok := allPkgsMap[importPath]
+		if !ok {
+			return nil, nil, fmt.Errorf("package %q not found in map", importPath)
+		}
+
+		// this is all that's need to be printed to be a valid test
+		textToWrite := "package " + p.Name + "\n"
+
+		file, err := os.CreateTemp(p.Dir, "dummy_*_test.go")
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// we know we can write to dummy_test, because there is no test in the package
+		err = os.WriteFile(file.Name(), []byte(textToWrite), 0o666)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		newFiles = append(newFiles, file.Name())
+		packages = append(packages, p)
+	}
+	return newFiles, packages, nil
+}
+
 func RunTests(opts RunTestsOpts) error {
+
+	// function to inject that actually "prints" each line
+	lineOut := func(str ...string) { fmt.Println(strings.Join(str, " ")) }
+
+	var newFiles []string
+	var newPackages []Package
+	if opts.FlagFullCoverage {
+		lineOut(sf("\nGenerating empty tests for full coverage in '%s'", opts.TestPath))
+
+		var err error
+		newFiles, newPackages, err = initEmpty(opts.TestPath, opts.Excludes)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			for _, f := range newFiles {
+				os.Remove(f)
+			}
+		}()
+	}
+
 	color.NoColor = !opts.FlagColor
-	coverProfile := zvfb(opts.FlagCoverProfile, "./coverage.out")
 
 	// Get list of all packages in the test path
 	allPkgsStr, err := shCmd("go", shArgs{"list", opts.TestPath}, "")
@@ -48,11 +169,20 @@ func RunTests(opts RunTestsOpts) error {
 		return err
 	}
 
-	// function to inject that actually "prints" each line
-	lineOut := func(str ...string) { fmt.Println(strings.Join(str, " ")) }
-
 	// channel to receive each 'go test' stdout line
 	goTestOutput := make(chan TestEvent)
+
+	var coverProfile string
+	if opts.FlagCoverReport {
+		coverProfile = zvfb(opts.FlagCoverProfile, "./coverage.out")
+	} else if opts.FlagFullCoverage {
+		newF, err := os.CreateTemp("", "coverage-*.out")
+		if err != nil {
+			return err
+		}
+		defer os.Remove(newF.Name())
+		coverProfile = newF.Name()
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -68,6 +198,8 @@ func RunTests(opts RunTestsOpts) error {
 			FlagListEmpty:   opts.FlagListEmpty,
 			FlagListIgnored: opts.FlagListIgnored,
 			IndentSpaces:    2,
+			DummyPackages:   newPackages,
+			AverageCoverage: coverProfile == "",
 		})
 		wg.Done()
 	}()
@@ -78,18 +210,61 @@ func RunTests(opts RunTestsOpts) error {
 	testArgs = sliceAppendIf(opts.FlagVerbose, testArgs, "-v")
 	testArgs = sliceAppendIf(!opts.FlagCache, testArgs, "-count=1")
 	testArgs = sliceAppendIf(opts.FlagCover, testArgs, "-cover")
-	testArgs = sliceAppendIf(opts.FlagCoverProfile != "" || opts.FlagCoverReport, testArgs, "-coverprofile="+coverProfile)
+	testArgs = sliceAppendIf(coverProfile != "", testArgs, "-coverprofile="+coverProfile)
 	testArgs = append(testArgs, "-json")
 	testArgs = append(testArgs, testPkgs...)
 	err = shJSONPipe("go", testArgs, "", goTestOutput)
 	wg.Wait()
 	if err != nil {
+		if coverProfile != "" {
+			// print coverage even in the case of error (as test failure is error here); ignore its own error
+			printCoverage(coverProfile, lineOut)
+		}
 		return err
+	}
+
+	if coverProfile != "" {
+		err = printCoverage(coverProfile, lineOut)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Open html coverage report
 	if opts.FlagCoverReport {
 		shCmd("go", shArgs{"tool", "cover", "-html=" + coverProfile}, "")
 	}
+	return nil
+}
+
+func printCoverage(path string, lineOut func(...string)) error {
+	var coverage float64
+
+	// now read proper code coverage
+	goCoverOutput := make(chan string)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		for line := range goCoverOutput {
+			if strings.HasPrefix(line, "total:") {
+				// a bit of a hack but it works
+				line = strings.Trim(line, "total: (statements) %\t\n")
+				coverage, _ = strconv.ParseFloat(line, 64)
+			}
+		}
+		wg.Done()
+	}()
+
+	err := shPipe("go", shArgs{"tool", "cover", "-func", path}, "", goCoverOutput)
+	if err != nil {
+		return err
+	}
+
+	chev := shColor("gray", "❯")
+	cover := sf("%.2f", coverage) + "%"
+
+	lineOut(sf("%s Coverage: %s", chev, shColor(coverageColor(coverage)+":bold", cover)))
 	return nil
 }

--- a/internal/output_test.go
+++ b/internal/output_test.go
@@ -30,6 +30,7 @@ func runTests(p *processOutputParams, outLines ...TestEvent) []string {
 			FlagListEmpty:   p.FlagListEmpty,
 			FlagListIgnored: p.FlagListIgnored,
 			IndentSpaces:    2,
+			AverageCoverage: true,
 		})
 		wg.Done()
 	}()
@@ -59,13 +60,13 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "pass", Package: "tst", Elapsed: 0.266},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"✔ tst              0.266s",
 			"",
-			"❯ Coverage: 0.00%",
+			"❯ Average Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
 			"",
-		})
+		}, out)
 	})
 
 	t.Run("one dummy test, coverage flag", func(t *testing.T) {
@@ -82,13 +83,13 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "pass", Package: "tst", Elapsed: 0.266},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"✔ tst     0.0%     0.266s",
 			"",
-			"❯ Coverage: 0.00%",
+			"❯ Average Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
 			"",
-		})
+		}, out)
 	})
 
 	// with the new logic, skipped are written only on verbose
@@ -108,15 +109,15 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "pass", Package: "tst", Elapsed: 0.266},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"≋ TestOther     skipped",
 			"  code_test.go:10: some reason to skip",
 			"✔ tst              0.266s",
 			"",
-			"❯ Coverage: 0.00%",
+			"❯ Average Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
 			"",
-		})
+		}, out)
 	})
 
 	t.Run("failing test", func(t *testing.T) {
@@ -136,17 +137,17 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "fail", Package: "tst", Elapsed: 0.308},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"✖ TestFailing",
 			"if you having correctness problems i feel bad for you son",
 			"i've got 99 problems",
 			"  code_test.go:12: but a test ain't one",
 			"◼ tst              0.308s",
 			"",
-			"❯ Coverage: 0.00%",
+			"❯ Average Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 1    noTests: 0    excluded: 0",
 			"",
-		})
+		}, out)
 	})
 
 	t.Run("no tests line (no skip)", func(t *testing.T) {
@@ -157,13 +158,13 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "skip", Package: "tst", Elapsed: 0},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"! tst     0.0%     no tests",
 			"",
-			"❯ Coverage: 0.00%",
+			"❯ Average Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 1    excluded: 0",
 			"",
-		})
+		}, out)
 	})
 
 	t.Run("no tests line (skip)", func(t *testing.T) {
@@ -174,12 +175,12 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "skip", Package: "tst", Elapsed: 0},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"",
-			"❯ Coverage: 0.00%",
+			"❯ Average Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 1    excluded: 0",
 			"",
-		})
+		}, out)
 	})
 
 	t.Run("no tests line (list)", func(t *testing.T) {
@@ -190,15 +191,15 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "skip", Package: "tst", Elapsed: 0},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"! tst     0.0%     no tests",
 			"",
-			"❯ Coverage: 0.00%",
+			"❯ Average Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 1    excluded: 0",
 			"",
 			"Packages with no tests:",
 			"- tst",
-		})
+		}, out)
 	})
 
 	t.Run("ok line, coverage", func(t *testing.T) {
@@ -216,13 +217,13 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "pass", Package: "tst", Elapsed: 0.186},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"✔ tst    50.0%     0.186s",
 			"",
-			"❯ Coverage: 50.00%",
+			"❯ Average Coverage: 50.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
 			"",
-		})
+		}, out)
 	})
 
 	t.Run("coverage no statements", func(t *testing.T) {
@@ -240,13 +241,13 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "pass", Package: "tst", Elapsed: 0.11},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"✔ tst        -     no statements",
 			"",
-			"❯ Coverage: 0.00%",
+			"❯ Average Coverage: 0.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
 			"",
-		})
+		}, out)
 	})
 
 	t.Run("one test fail, one succseccful, no verbose, coverage", func(t *testing.T) {
@@ -273,17 +274,17 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "fail", Package: "tst", Elapsed: 0.108},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"✖ TestFailing",
 			"if you having correctness problems i feel bad for you son",
 			"i've got 99 problems",
 			"  code_test.go:12: but a test ain't one",
 			"◼ tst    50.0%     0.108s",
 			"",
-			"❯ Coverage: 50.00%",
+			"❯ Average Coverage: 50.00%",
 			"❯ Pkgs: tested: 1    failed: 1    noTests: 0    excluded: 0",
 			"",
-		})
+		}, out)
 	})
 
 	t.Run("one test fail, one succseccful, verbose, coverage", func(t *testing.T) {
@@ -310,7 +311,7 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "fail", Package: "tst", Elapsed: 0.108},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"✖ TestFailing",
 			"if you having correctness problems i feel bad for you son",
 			"i've got 99 problems",
@@ -321,9 +322,9 @@ func TestProcessOutput(t *testing.T) {
 			"◼ tst    50.0%     0.108s",
 			"-------------------------",
 			"",
-			"❯ Coverage: 50.00%",
+			"❯ Average Coverage: 50.00%",
 			"❯ Pkgs: tested: 1    failed: 1    noTests: 0    excluded: 0",
-			""})
+			""}, out)
 	})
 
 	t.Run("ignored, no list", func(t *testing.T) {
@@ -341,13 +342,13 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "pass", Package: "tst", Elapsed: 0.186},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"✔ tst    50.0%     0.186s",
 			"",
-			"❯ Coverage: 50.00%",
+			"❯ Average Coverage: 50.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 1",
 			"",
-		})
+		}, out)
 	})
 
 	t.Run("ignored, list", func(t *testing.T) {
@@ -365,15 +366,15 @@ func TestProcessOutput(t *testing.T) {
 			TestEvent{Action: "pass", Package: "tst", Elapsed: 0.186},
 		)
 
-		assert.Equal(t, out, []string{
+		assert.Equal(t, []string{
 			"✔ tst    50.0%     0.186s",
 			"",
-			"❯ Coverage: 50.00%",
+			"❯ Average Coverage: 50.00%",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 1",
 			"",
 			"Packages ignored:",
 			"- tst/ignored",
-		})
+		}, out)
 	})
 }
 

--- a/internal/shell_test.go
+++ b/internal/shell_test.go
@@ -47,6 +47,25 @@ func TestShJSONPipe(t *testing.T) {
 	})
 }
 
+func TestShPipe(t *testing.T) {
+	out := []string{}
+	c := make(chan string)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		for line := range c {
+			out = append(out, line)
+		}
+		wg.Done()
+	}()
+
+	shPipe("echo", shArgs{"Hello\nWorld"}, "", c)
+	wg.Wait()
+
+	assert.Equal(t, out, []string{"Hello", "World"})
+}
+
 func TestShColor(t *testing.T) {
 	t.Run("no color", func(t *testing.T) {
 		color.NoColor = true


### PR DESCRIPTION
We need to do two things for that: First is to create empty tests, and then to take coverage report, run go cov on it and take the full coverage there.

For the first part - creating empty tests - it's a little tricky.

* first we list all packages, to get file paths/names
* then we get all the packages without tests, through go test list
* then we create dummy test files
* then we run the gotestiful
* then we remove the dummy files

We need to do some trickery to still print the originally no-test files as skipped.

For the second part - we need to save the go coverage file always, but in the case user doesn't want it, delete it again.