### PR TITLE
Save to cover profile even when report is false

### DIFF
--- a/.gotestiful
+++ b/.gotestiful
@@ -3,7 +3,7 @@
   "cache": true,
   "cover": true,
   "report": false,
-  "coverProfile": "",
+  "coverProfile": "./coverage.out",
   "verbose": false,
   "listIgnored": false,
   "skipEmpty": true,

--- a/internal/main.go
+++ b/internal/main.go
@@ -175,7 +175,7 @@ func RunTests(opts RunTestsOpts) error {
 	goTestOutput := make(chan TestEvent)
 
 	var coverProfile string
-	if opts.FlagCoverReport {
+	if opts.FlagCoverReport || opts.FlagCoverProfile != "" {
 		coverProfile = zvfb(opts.FlagCoverProfile, "./coverage.out")
 	} else if opts.FlagFullCoverage {
 		newF, err := os.CreateTemp("", "coverage-*.out")


### PR DESCRIPTION
report is for opening HTML file, while we want to be able to export to out even when we dont want to open HTML