### PR TITLE
fix: coverage calc + pkgs list building

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.6
+        go-version: 1.20.2
 
     - name: Build
       run: go build -v ./...

--- a/internal/azure.go
+++ b/internal/azure.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 )
 
 type AzureBody struct {
@@ -26,6 +25,7 @@ type AzureConf struct {
 func makeComment(coverage float64, badTests []string) string {
 	coverageComment := "Total coverage is " + sf("%.2f", coverage) + "%"
 	testComment := "All tests are successful. 💪\n\n"
+
 	if len(badTests) != 0 {
 		testComment = "Test failed. 🙅 \n\n Failed tests:\n\n"
 		testComment += "|Test name|\n|--------|\n"
@@ -34,6 +34,7 @@ func makeComment(coverage float64, badTests []string) string {
 		}
 		testComment += "\n"
 	}
+
 	return testComment + coverageComment
 }
 
@@ -41,6 +42,7 @@ func (az AzureConf) sendAzureComment(coverage float64, failedTests []string) err
 	if az.URL == "" {
 		return nil
 	}
+
 	dat, err := json.Marshal(AzureBody{
 		Status: 2,
 		Comments: []AzureComment{{
@@ -58,12 +60,9 @@ func (az AzureConf) sendAzureComment(coverage float64, failedTests []string) err
 		return err
 	}
 
-	fmt.Println("will do request")
 	req.Header.Add("Authorization", "Bearer "+az.Auth)
 	req.Header.Set("Content-Type", "application/json")
 
-	dump, _ := httputil.DumpRequestOut(req, true)
-	fmt.Printf("Request: %s\n", dump)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		fmt.Printf("Error: %+v", err)
@@ -72,7 +71,5 @@ func (az AzureConf) sendAzureComment(coverage float64, failedTests []string) err
 
 	defer resp.Body.Close()
 
-	dump, _ = httputil.DumpResponse(resp, true)
-	fmt.Printf("Response: %s\n", dump)
 	return nil
 }

--- a/internal/filesys.go
+++ b/internal/filesys.go
@@ -34,3 +34,9 @@ func readFile(filePath string) ([]byte, error) {
 
 	return fileBytes, nil
 }
+
+func deleteFiles(files *[]string) {
+	for _, f := range *files {
+		os.Remove(f)
+	}
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -58,35 +58,28 @@ func RunTests(opts RunTestsOpts) error {
 	// function to inject that actually "prints" each line
 	lineOut := func(str ...string) { fmt.Println(strings.Join(str, " ")) }
 
+	// Get packages to test
+	testPkgsMap, testPkgs, ignoredPkgs, err := getPackages(opts.TestPath, opts.Excludes)
+	if err != nil {
+		return err
+	}
+
+	// Create blank test files in no-tests packages (needed for fullCoverage)
 	var newFiles []string
 	var newPackages []Package
 	if opts.FlagFullCoverage {
 		lineOut(sf("\nGenerating empty tests for full coverage in '%s'", opts.TestPath))
 
 		var err error
-		newFiles, newPackages, err = initEmpty(opts.TestPath, opts.Excludes)
+		newFiles, newPackages, err = fixPkgsWithNoTests(testPkgsMap, testPkgs)
 		if err != nil {
 			return err
 		}
-		defer func() {
-			for _, f := range newFiles {
-				os.Remove(f)
-			}
-		}()
+
+		defer deleteFiles(&newFiles)
 	}
 
-	// Get list of all packages in the test path
-	allPkgsStr, err := shCmd("go", shArgs{"list", opts.TestPath}, "")
-	if err != nil {
-		return err
-	}
-	allPkgs := splitLines(allPkgsStr)
-
-	testPkgs, ignoredPkgs, err := excludePackages(allPkgs, opts.Excludes)
-	if err != nil {
-		return err
-	}
-
+	// Determine cover-profile file name
 	var coverProfile string
 	if opts.FlagCoverReport || opts.FlagFullCoverage {
 		coverProfile = opts.FlagCoverProfile
@@ -119,7 +112,7 @@ func RunTests(opts RunTestsOpts) error {
 			FlagListEmpty:   opts.FlagListEmpty,
 			FlagListIgnored: opts.FlagListIgnored,
 			IndentSpaces:    2,
-			DummyPackages:   newPackages,
+			NoTestsPackages: newPackages,
 			CoverProfile:    coverProfile,
 			FailedTests:     &failedTests,
 			TotalCoverage:   &totalCoverage,
@@ -163,87 +156,83 @@ func RunTests(opts RunTestsOpts) error {
 	return nil
 }
 
-// Add dummy test files to packages with no tests
-func initEmpty(testPath string, excludes []string) (newFiles []string, packages []Package, err error) {
+// Helpers --------------
+
+func getPackages(testPath string, excludes []string) (map[string]Package, []string, []string, error) {
 	allPkgs := []string{}
 	allPkgsMap := map[string]Package{}
 
-	{
-		pkgChan := make(chan Package)
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			for p := range pkgChan {
-				allPkgs = append(allPkgs, p.ImportPath)
-				allPkgsMap[p.ImportPath] = p
-			}
-			wg.Done()
-		}()
-		err := shJSONPipe("go", shArgs{"list", "-json", testPath}, "", pkgChan, io.Discard)
-		wg.Wait()
-		if err != nil {
-			return nil, nil, err
+	// Load all packages
+	pkgChan := make(chan Package)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		for p := range pkgChan {
+			allPkgs = append(allPkgs, p.ImportPath)
+			allPkgsMap[p.ImportPath] = p
 		}
-	}
-
-	skippedPkgs := []string{}
-
-	{
-		testPkgs, _, err := excludePackages(allPkgs, excludes)
-
-		if err != nil {
-			return nil, nil, err
-		}
-
-		goListOutput := make(chan TestEvent)
-
-		var wg sync.WaitGroup
-		wg.Add(1)
-
-		go func() {
-			for o := range goListOutput {
-				if o.Action == "skip" && o.Test == "" {
-					skippedPkgs = append(skippedPkgs, o.Package)
-				}
-			}
-
-			wg.Done()
-		}()
-
-		testArgs := shArgs{"test"}
-		testArgs = append(testArgs, "-list", ".")
-		testArgs = append(testArgs, "-json")
-		testArgs = append(testArgs, testPkgs...)
-		err = shJSONPipe("go", testArgs, "", goListOutput, io.Discard)
-		wg.Wait()
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	defer func() {
-		if err != nil {
-			for _, f := range newFiles {
-				os.Remove(f)
-			}
-		}
+		wg.Done()
 	}()
 
-	for _, importPath := range skippedPkgs {
-		p, ok := allPkgsMap[importPath]
-		if !ok {
-			return nil, nil, fmt.Errorf("package %q not found in map", importPath)
+	err := shJSONPipe("go", shArgs{"list", "-json", testPath}, "", pkgChan, io.Discard)
+	wg.Wait()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Exclude packages to ignore
+	pkgsToTest, pkgsIgnored, err := excludePackages(allPkgs, excludes)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Build packages to test map
+	pkgsToTestMap := map[string]Package{}
+	for _, pkg := range pkgsToTest {
+		pkgsToTestMap[pkg] = allPkgsMap[pkg]
+	}
+
+	return pkgsToTestMap, pkgsToTest, pkgsIgnored, nil
+}
+
+// "Eliminate" no-tests pakages by creating blank test file in them
+func fixPkgsWithNoTests(pkgsMap map[string]Package, pkgs []string) (newFiles []string, packages []Package, err error) {
+	noTestsPkgs := []string{}
+	goListOutput := make(chan TestEvent)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		for o := range goListOutput {
+			if o.Action == "skip" && o.Test == "" {
+				noTestsPkgs = append(noTestsPkgs, o.Package)
+			}
 		}
 
-		// this is all that's need to be printed to be a valid test
-		textToWrite := "package " + p.Name + "\n"
+		wg.Done()
+	}()
+
+	testArgs := shArgs{"test"}
+	testArgs = append(testArgs, "-list", ".")
+	testArgs = append(testArgs, "-json")
+	testArgs = append(testArgs, pkgs...)
+	err = shJSONPipe("go", testArgs, "", goListOutput, io.Discard)
+	wg.Wait()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Create blank test file in each no-test package
+	for _, pkg := range noTestsPkgs {
+		p := pkgsMap[pkg]
 
 		file, err := os.CreateTemp(p.Dir, "dummy_*_test.go")
 		if err != nil {
 			return nil, nil, err
 		}
 
-		// we know we can write to dummy_test, because there is no test in the package
+		textToWrite := fmt.Sprintf("package %s\n", p.Name) // all that's need to be a valid test
 		err = os.WriteFile(file.Name(), []byte(textToWrite), 0o666)
 		if err != nil {
 			return nil, nil, err
@@ -252,5 +241,6 @@ func initEmpty(testPath string, excludes []string) (newFiles []string, packages 
 		newFiles = append(newFiles, file.Name())
 		packages = append(packages, p)
 	}
+
 	return newFiles, packages, nil
 }

--- a/internal/main.go
+++ b/internal/main.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -89,8 +87,6 @@ func RunTests(opts RunTestsOpts) error {
 		return err
 	}
 
-	var failedTests []string
-
 	var coverProfile string
 	if opts.FlagCoverReport || opts.FlagFullCoverage {
 		coverProfile = opts.FlagCoverProfile
@@ -107,7 +103,10 @@ func RunTests(opts RunTestsOpts) error {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
+
 	goTestOutput := make(chan TestEvent) // channel to receive each 'go test' stdout line
+	var failedTests []string
+	var totalCoverage float64
 
 	go func() {
 		processOutput(&processOutputParams{
@@ -121,8 +120,9 @@ func RunTests(opts RunTestsOpts) error {
 			FlagListIgnored: opts.FlagListIgnored,
 			IndentSpaces:    2,
 			DummyPackages:   newPackages,
-			AverageCoverage: coverProfile == "",
+			CoverProfile:    coverProfile,
 			FailedTests:     &failedTests,
+			TotalCoverage:   &totalCoverage,
 		})
 		wg.Done()
 	}()
@@ -148,20 +148,11 @@ func RunTests(opts RunTestsOpts) error {
 	testErr := shJSONPipe("go", testArgs, "", goTestOutput, testOut)
 	wg.Wait()
 
-	var covErr error
-	if opts.FlagFullCoverage {
-		cov, covErr := printCoverage(coverProfile, lineOut)
-		if covErr == nil {
-			opts.Azure.sendAzureComment(cov, failedTests)
-		}
-	}
+	// Publish Azure Coverage PR comment
+	opts.Azure.sendAzureComment(totalCoverage, failedTests)
 
 	if testErr != nil {
 		return ErrTestRunIgnore
-	}
-
-	if covErr != nil {
-		return covErr
 	}
 
 	// Open html coverage report
@@ -262,34 +253,4 @@ func initEmpty(testPath string, excludes []string) (newFiles []string, packages 
 		packages = append(packages, p)
 	}
 	return newFiles, packages, nil
-}
-
-func printCoverage(path string, lineOut func(...string)) (float64, error) {
-	regexTotalCov := regexp.MustCompile(`^total:\s+\(statements\)\s+(\d{1,3}\.\d{1,2}%)`)
-	goCoverOutput := make(chan string)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	var coverage float64
-	go func() {
-		for line := range goCoverOutput {
-			if strings.HasPrefix(line, "total:") {
-				cov := regexTotalCov.ReplaceAllString(line, "$1")
-				coverage, _ = strconv.ParseFloat(strings.Trim(cov, "% \t\n"), 64)
-			}
-		}
-		wg.Done()
-	}()
-
-	err := shPipe("go", shArgs{"tool", "cover", "-func", path}, "", goCoverOutput)
-	if err != nil {
-		return 0, err
-	}
-
-	covColor := coverageColor(coverage) + ":bold"
-	covFormatted := sf("%.2f", coverage) + "%"
-	lineOut(sf("%s Coverage: %s", shColor("gray", "❯"), shColor(covColor, covFormatted)))
-
-	return coverage, nil
 }

--- a/internal/maps.go
+++ b/internal/maps.go
@@ -1,0 +1,7 @@
+package internal
+
+// mapHasKey returns true if a map has the key provided
+func mapHasKey[K comparable, V any](m map[K]V, key K) bool {
+	_, ok := m[key]
+	return ok
+}

--- a/internal/maps_test.go
+++ b/internal/maps_test.go
@@ -1,0 +1,21 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapHasKey(t *testing.T) {
+	t.Run("with non existent keys", func(t *testing.T) {
+		m := map[string]bool{"hello": true, "world": true}
+		actual := mapHasKey(m, "foo")
+		assert.False(t, actual)
+	})
+
+	t.Run("with existent keys", func(t *testing.T) {
+		m := map[string]bool{"hello": true, "world": true}
+		actual := mapHasKey(m, "hello")
+		assert.True(t, actual)
+	})
+}

--- a/internal/output_test.go
+++ b/internal/output_test.go
@@ -30,7 +30,7 @@ func runTests(p *processOutputParams, outLines ...TestEvent) []string {
 			FlagListEmpty:   p.FlagListEmpty,
 			FlagListIgnored: p.FlagListIgnored,
 			IndentSpaces:    2,
-			AverageCoverage: true,
+			CoverProfile:    "",
 		})
 		wg.Done()
 	}()
@@ -64,7 +64,7 @@ func TestProcessOutput(t *testing.T) {
 			"✔ tst              0.266s",
 			"",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
-			"❯ Coverage: 0.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 0.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 		}, out)
 	})
 
@@ -86,7 +86,7 @@ func TestProcessOutput(t *testing.T) {
 			"✔ tst     0.0%     0.266s",
 			"",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
-			"❯ Coverage: 0.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 0.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 		}, out)
 	})
 
@@ -114,7 +114,7 @@ func TestProcessOutput(t *testing.T) {
 			"-------------------------",
 			"",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
-			"❯ Coverage: 0.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 0.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 		}, out)
 	})
 
@@ -143,7 +143,7 @@ func TestProcessOutput(t *testing.T) {
 			"◼ tst              0.308s",
 			"",
 			"❯ Pkgs: tested: 1    failed: 1    noTests: 0    excluded: 0",
-			"❯ Coverage: 0.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 0.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 		}, out)
 	})
 
@@ -159,7 +159,7 @@ func TestProcessOutput(t *testing.T) {
 			"! tst     0.0%     no tests",
 			"",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 1    excluded: 0",
-			"❯ Coverage: 0.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 0.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 		}, out)
 	})
 
@@ -174,7 +174,7 @@ func TestProcessOutput(t *testing.T) {
 		assert.Equal(t, []string{
 			"",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 1    excluded: 0",
-			"❯ Coverage: 0.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 0.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 		}, out)
 	})
 
@@ -190,7 +190,7 @@ func TestProcessOutput(t *testing.T) {
 			"! tst     0.0%     no tests",
 			"",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 1    excluded: 0",
-			"❯ Coverage: 0.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 0.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 			"",
 			"Packages with no tests:",
 			"- tst",
@@ -216,7 +216,7 @@ func TestProcessOutput(t *testing.T) {
 			"✔ tst    50.0%     0.186s",
 			"",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
-			"❯ Coverage: 50.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 50.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 		}, out)
 	})
 
@@ -239,7 +239,7 @@ func TestProcessOutput(t *testing.T) {
 			"✔ tst        -     no statements",
 			"",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 0",
-			"❯ Coverage: 0.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 0.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 		}, out)
 	})
 
@@ -275,7 +275,7 @@ func TestProcessOutput(t *testing.T) {
 			"◼ tst    50.0%     0.108s",
 			"",
 			"❯ Pkgs: tested: 1    failed: 1    noTests: 0    excluded: 0",
-			"❯ Coverage: 50.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 50.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 		}, out)
 	})
 
@@ -315,7 +315,7 @@ func TestProcessOutput(t *testing.T) {
 			"-------------------------",
 			"",
 			"❯ Pkgs: tested: 1    failed: 1    noTests: 0    excluded: 0",
-			"❯ Coverage: 50.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 50.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 		}, out)
 	})
 
@@ -338,7 +338,7 @@ func TestProcessOutput(t *testing.T) {
 			"✔ tst    50.0%     0.186s",
 			"",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 1",
-			"❯ Coverage: 50.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 50.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 		}, out)
 	})
 
@@ -361,7 +361,7 @@ func TestProcessOutput(t *testing.T) {
 			"✔ tst    50.0%     0.186s",
 			"",
 			"❯ Pkgs: tested: 1    failed: 0    noTests: 0    excluded: 1",
-			"❯ Coverage: 50.00%   [average]   (set flag 'fullCoverage' for accurate calculation)",
+			"❯ Coverage: 50.00%   [average]    (set flag 'fullCoverage' for accurate calculation)",
 			"",
 			"Packages ignored:",
 			"- tst/ignored",


### PR DESCRIPTION
- fix: calculate coverage from cover-profile file instead of running `go tool cover`
- fix: optimize building list of pkgs to improve runtime
- fix: ensure output lines after test summary line are printed